### PR TITLE
Renamed most of the browser operations and changed the API to be non-fluent

### DIFF
--- a/webtester-core/src/main/java/info/novatec/testit/webtester/browser/Browser.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/browser/Browser.java
@@ -3,13 +3,13 @@ package info.novatec.testit.webtester.browser;
 import org.openqa.selenium.WebDriver;
 
 import info.novatec.testit.webtester.browser.operations.AlertHandler;
-import info.novatec.testit.webtester.browser.operations.Focus;
-import info.novatec.testit.webtester.browser.operations.JavaScript;
-import info.novatec.testit.webtester.browser.operations.Navigate;
-import info.novatec.testit.webtester.browser.operations.Open;
-import info.novatec.testit.webtester.browser.operations.PageSource;
-import info.novatec.testit.webtester.browser.operations.Screenshot;
-import info.novatec.testit.webtester.browser.operations.Window;
+import info.novatec.testit.webtester.browser.operations.FocusSetter;
+import info.novatec.testit.webtester.browser.operations.JavaScriptExecutor;
+import info.novatec.testit.webtester.browser.operations.Navigator;
+import info.novatec.testit.webtester.browser.operations.UrlOpener;
+import info.novatec.testit.webtester.browser.operations.PageSourceSaver;
+import info.novatec.testit.webtester.browser.operations.ScreenshotTaker;
+import info.novatec.testit.webtester.browser.operations.CurrentWindow;
 import info.novatec.testit.webtester.config.Configuration;
 import info.novatec.testit.webtester.events.EventSystem;
 import info.novatec.testit.webtester.pagefragments.PageFragment;
@@ -54,14 +54,14 @@ import info.novatec.testit.webtester.internal.OffersPageCreation;
  * @see BrowserBuilder
  * @see BrowserFactory
  * @see Configuration
- * @see Open
- * @see Window
- * @see Navigate
- * @see Focus
+ * @see UrlOpener
+ * @see CurrentWindow
+ * @see Navigator
+ * @see FocusSetter
  * @see AlertHandler
- * @see Screenshot
- * @see PageSource
- * @see JavaScript
+ * @see ScreenshotTaker
+ * @see PageSourceSaver
+ * @see JavaScriptExecutor
  * @since 2.0
  */
 public interface Browser extends OffersPageCreation, OffersAdHocFinding {
@@ -98,44 +98,45 @@ public interface Browser extends OffersPageCreation, OffersAdHocFinding {
 	 
      * @param url the URL to open
      * @return the same instance for fluent API use
-     * @see Open#url(String)
+     * @see UrlOpener#url(String)
      * @since 2.0
      */
     default Browser open(String url) {
-        return open().url(url);
+        open().url(url);
+        return this;
     }
 
     /**
-     * Returns this {@link Browser browser's} {@link Open open} operations.
+     * Returns this {@link Browser browser's} {@link UrlOpener open} operations.
      *
      * @return the open operations
      * @since 2.0
      */
-    Open open();
+    UrlOpener open();
 
     /**
-     * Returns this {@link Browser browser's} {@link Window window} operations.
+     * Returns this {@link Browser browser's} {@link CurrentWindow window} operations.
      *
      * @return the window operations
      * @since 2.0
      */
-    Window currentWindow();
+    CurrentWindow currentWindow();
 
     /**
-     * Returns this {@link Browser browser's} {@link Navigate navigation} operations.
+     * Returns this {@link Browser browser's} {@link Navigator navigation} operations.
      *
      * @return the navigation operations
      * @since 2.0
      */
-    Navigate navigate();
+    Navigator navigate();
 
     /**
-     * Returns this {@link Browser browser's} {@link Focus focus} operations.
+     * Returns this {@link Browser browser's} {@link FocusSetter focus} operations.
      *
      * @return the focus operations
      * @since 2.0
      */
-    Focus focus();
+    FocusSetter focus();
 
     /**
      * Returns this {@link Browser browser's} {@link AlertHandler alert} operations.
@@ -146,28 +147,28 @@ public interface Browser extends OffersPageCreation, OffersAdHocFinding {
     AlertHandler alert();
 
     /**
-     * Returns this {@link Browser browser's} {@link Screenshot screenshot} operations.
+     * Returns this {@link Browser browser's} {@link ScreenshotTaker screenshot} operations.
      *
      * @return the screenshot operations
      * @since 2.0
      */
-    Screenshot screenshot();
+    ScreenshotTaker screenshot();
 
     /**
-     * Returns this {@link Browser browser's} {@link PageSource page source} operations.
+     * Returns this {@link Browser browser's} {@link PageSourceSaver page source} operations.
      *
      * @return the page source operations
      * @since 2.0
      */
-    PageSource pageSource();
+    PageSourceSaver pageSource();
 
     /**
-     * Returns this {@link Browser browser's} {@link JavaScript} operations.
+     * Returns this {@link Browser browser's} {@link JavaScriptExecutor} operations.
      *
      * @return the JavaScript operations
      * @since 2.0
      */
-    JavaScript javaScript();
+    JavaScriptExecutor javaScript();
 
 
     /**

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/browser/WebDriverBrowser.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/browser/WebDriverBrowser.java
@@ -6,13 +6,13 @@ import org.openqa.selenium.WebDriver;
 import lombok.extern.slf4j.Slf4j;
 
 import info.novatec.testit.webtester.browser.operations.AlertHandler;
-import info.novatec.testit.webtester.browser.operations.Focus;
-import info.novatec.testit.webtester.browser.operations.JavaScript;
-import info.novatec.testit.webtester.browser.operations.Navigate;
-import info.novatec.testit.webtester.browser.operations.Open;
-import info.novatec.testit.webtester.browser.operations.PageSource;
-import info.novatec.testit.webtester.browser.operations.Screenshot;
-import info.novatec.testit.webtester.browser.operations.Window;
+import info.novatec.testit.webtester.browser.operations.FocusSetter;
+import info.novatec.testit.webtester.browser.operations.JavaScriptExecutor;
+import info.novatec.testit.webtester.browser.operations.Navigator;
+import info.novatec.testit.webtester.browser.operations.UrlOpener;
+import info.novatec.testit.webtester.browser.operations.PageSourceSaver;
+import info.novatec.testit.webtester.browser.operations.ScreenshotTaker;
+import info.novatec.testit.webtester.browser.operations.CurrentWindow;
 import info.novatec.testit.webtester.config.Configuration;
 import info.novatec.testit.webtester.config.builders.DefaultConfigurationBuilder;
 import info.novatec.testit.webtester.events.EventSystem;
@@ -47,18 +47,18 @@ public final class WebDriverBrowser implements Browser {
 
     private final WebDriver webDriver;
 
-    private final Open open;
-    private final Window window;
-    private final Navigate navigate;
+    private final UrlOpener open;
+    private final CurrentWindow window;
+    private final Navigator navigate;
     private final AlertHandler alert;
-    private final Screenshot screenshot;
-    private final PageSource pageSource;
-    private final JavaScript javaScript;
+    private final ScreenshotTaker screenshot;
+    private final PageSourceSaver pageSource;
+    private final JavaScriptExecutor javaScript;
     private final EventSystem eventSystem;
     private final AdHocFinder adHocFinder;
     private final PageFactory pageFactory;
 
-    private final Focus focus;
+    private final FocusSetter focus;
     private boolean closed;
 
     private WebDriverBrowser(Configuration configuration, WebDriver webDriver) {
@@ -66,14 +66,14 @@ public final class WebDriverBrowser implements Browser {
         this.configuration = configuration;
         this.webDriver = webDriver;
 
-        this.open = new Open(this);
-        this.window = new Window(this);
-        this.navigate = new Navigate(this);
+        this.open = new UrlOpener(this);
+        this.window = new CurrentWindow(this);
+        this.navigate = new Navigator(this);
         this.alert = new AlertHandler(this);
-        this.screenshot = new Screenshot(this);
-        this.pageSource = new PageSource(this);
-        this.javaScript = new JavaScript(this);
-        this.focus = new Focus(this);
+        this.screenshot = new ScreenshotTaker(this);
+        this.pageSource = new PageSourceSaver(this);
+        this.javaScript = new JavaScriptExecutor(this);
+        this.focus = new FocusSetter(this);
         this.eventSystem = new EventSystemImpl(this);
         this.adHocFinder = new AdHocFinder(this);
         this.pageFactory = new PageFactory(this);
@@ -124,22 +124,22 @@ public final class WebDriverBrowser implements Browser {
     }
 
     @Override
-    public Open open() {
+    public UrlOpener open() {
         return open;
     }
 
     @Override
-    public Window currentWindow() {
+    public CurrentWindow currentWindow() {
         return window;
     }
 
     @Override
-    public Focus focus() {
+    public FocusSetter focus() {
         return focus;
     }
 
     @Override
-    public Navigate navigate() {
+    public Navigator navigate() {
         return navigate;
     }
 
@@ -149,17 +149,17 @@ public final class WebDriverBrowser implements Browser {
     }
 
     @Override
-    public Screenshot screenshot() {
+    public ScreenshotTaker screenshot() {
         return screenshot;
     }
 
     @Override
-    public PageSource pageSource() {
+    public PageSourceSaver pageSource() {
         return pageSource;
     }
 
     @Override
-    public JavaScript javaScript() {
+    public JavaScriptExecutor javaScript() {
         return javaScript;
     }
 

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/browser/operations/AlertHandler.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/browser/operations/AlertHandler.java
@@ -44,13 +44,12 @@ public class AlertHandler extends BaseBrowserOperation {
      *
      * @param username the username to use
      * @param password the password to use
-     * @return the original browser of this operation
      * @see Alert#authenticateUsing(Credentials)
      * @since 2.0
      */
     @Beta
-    public Browser authenticateWith(String username, String password) {
-        return authenticateWith(new UserAndPassword(username, password));
+    public void authenticateWith(String username, String password) {
+        authenticateWith(new UserAndPassword(username, password));
     }
 
     /**
@@ -59,15 +58,13 @@ public class AlertHandler extends BaseBrowserOperation {
      * This operation is decalred as "BETA" by the Selenium developers and might break in the future in case it changes.
      *
      * @param credentials the credentials to use
-     * @return the original browser of this operation
      * @see Alert#authenticateUsing(Credentials)
      * @since 2.0
      */
     @Beta
-    public Browser authenticateWith(Credentials credentials) {
+    public void authenticateWith(Credentials credentials) {
         ActionTemplate.browser(browser()).execute(browser -> webDriver().switchTo().alert().authenticateUsing(credentials));
         log.debug("authenticated using credentials: {}", credentials);
-        return browser();
     }
 
     /**
@@ -76,17 +73,16 @@ public class AlertHandler extends BaseBrowserOperation {
      * <p>
      * Fires {@link AcceptedAlertEvent} in case a alert was successfully accepted.
      *
-     * @return the original browser of this operation
      * @see Alert#accept()
      * @since 2.0
      */
-    public Browser acceptIfPresent() {
+    public void acceptIfPresent() {
         if (isPresent()) {
             log.debug("alert was visible");
-            return accept();
+            accept();
+        } else {
+            log.debug("alert was not visible");
         }
-        log.debug("alert was not visible");
-        return browser();
     }
 
     /**
@@ -94,12 +90,11 @@ public class AlertHandler extends BaseBrowserOperation {
      * <p>
      * Fires {@link AcceptedAlertEvent} in case a alert was successfully accepted.
      *
-     * @return the original browser of this operation
      * @throws NoAlertPresentException in case no alert is present
      * @see Alert#accept()
      * @since 2.0
      */
-    public Browser accept() throws NoAlertPresentException {
+    public void accept() throws NoAlertPresentException {
         StringBuilder builder = new StringBuilder();
         ActionTemplate.browser(browser()).execute(browser -> {
             Alert alert = webDriver().switchTo().alert();
@@ -107,7 +102,6 @@ public class AlertHandler extends BaseBrowserOperation {
             alert.accept();
         }).fireEvent(browser -> new AcceptedAlertEvent(builder.toString()));
         log.debug("alert was accepted");
-        return browser();
     }
 
     /**
@@ -116,17 +110,16 @@ public class AlertHandler extends BaseBrowserOperation {
      * <p>
      * Fires {@link DeclinedAlertEvent} in case a alert was successfully accepted.
      *
-     * @return the original browser of this operation
      * @see Alert#dismiss()
      * @since 2.0
      */
-    public Browser declineIfPresent() {
+    public void declineIfPresent() {
         if (isPresent()) {
             log.debug("alert was visible");
-            return decline();
+            decline();
+        } else {
+            log.debug("alert was not visible");
         }
-        log.debug("alert was not visible");
-        return browser();
     }
 
     /**
@@ -134,12 +127,11 @@ public class AlertHandler extends BaseBrowserOperation {
      * <p>
      * Fires {@link DeclinedAlertEvent} in case a alert was successfully accepted.
      *
-     * @return the original browser of this operation
      * @throws NoAlertPresentException in case no alert is present
      * @see Alert#dismiss()
      * @since 2.0
      */
-    public Browser decline() throws NoAlertPresentException {
+    public void decline() throws NoAlertPresentException {
         StringBuilder builder = new StringBuilder();
         ActionTemplate.browser(browser()).execute(browser -> {
             Alert alert = webDriver().switchTo().alert();
@@ -147,7 +139,6 @@ public class AlertHandler extends BaseBrowserOperation {
             alert.dismiss();
         }).fireEvent(browser -> new DeclinedAlertEvent(builder.toString()));
         log.debug("alert was declined");
-        return browser();
     }
 
     /**

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/browser/operations/BaseBrowserOperation.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/browser/operations/BaseBrowserOperation.java
@@ -15,15 +15,15 @@ public class BaseBrowserOperation {
         this.browser = browser;
     }
 
-    protected final Browser browser() {
+    protected Browser browser() {
         return browser;
     }
 
-    protected final Configuration configuration() {
+    protected Configuration configuration() {
         return browser.configuration();
     }
 
-    protected final WebDriver webDriver() {
+    protected WebDriver webDriver() {
         return browser.webDriver();
     }
 

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/browser/operations/CurrentWindow.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/browser/operations/CurrentWindow.java
@@ -32,15 +32,15 @@ import info.novatec.testit.webtester.pagefragments.PageFragment;
  * @since 2.0
  */
 @Slf4j
-public class Window extends BaseBrowserOperation {
+public class CurrentWindow extends BaseBrowserOperation {
 
     /**
-     * Creates a new {@link Window} for the given {@link Browser}.
+     * Creates a new {@link CurrentWindow} for the given {@link Browser}.
      *
      * @param browser the browser to use
      * @since 2.0
      */
-    public Window(Browser browser) {
+    public CurrentWindow(Browser browser) {
         super(browser);
     }
 
@@ -60,31 +60,27 @@ public class Window extends BaseBrowserOperation {
     /**
      * Refreshes the content of the currently focused window.
      *
-     * @return the original browser of this operation
      * @see WebDriver.Navigation#refresh()
      * @since 2.0
      */
-    public Browser refresh() {
+    public void refresh() {
         ActionTemplate.browser(browser())
             .execute(browser -> browser.webDriver().navigate().refresh())
             .fireEvent(browser -> new RefreshedPageEvent());
         log.debug("refreshed current window ({})", getHandle());
-        return browser();
     }
 
     /**
      * Maximizes the currently focused window.
      *
-     * @return the original browser of this operation
      * @see WebDriver.Window#maximize()
      * @since 2.0
      */
-    public Browser maximize() {
+    public void maximize() {
         ActionTemplate.browser(browser())
             .execute(browser -> getWindowManager(browser).maximize())
             .fireEvent(browser -> new MaximizedWindowEvent());
         log.debug("maximized current window ({})", getHandle());
-        return browser();
     }
 
     /**
@@ -94,17 +90,15 @@ public class Window extends BaseBrowserOperation {
      * <p>
      * This feature should be used with caution!
      *
-     * @return the original browser of this operation
      * @since 2.0
      */
-    public Browser toggleFullScreen() {
+    public void toggleFullScreen() {
         ActionTemplate.browser(browser()).execute(browser -> {
             WebDriver webDriver = browser.webDriver();
             WebElement rootElement = webDriver.findElement(By.tagName("html"));
             rootElement.sendKeys(Keys.F11);
         });
         log.debug("made current window ({}) display in full screen", getHandle());
-        return browser();
     }
 
     /**
@@ -113,16 +107,14 @@ public class Window extends BaseBrowserOperation {
      *
      * @param x the X coordinate part (horizontal)
      * @param y the Y coordinate part (vertical)
-     * @return the original browser of this operation
      * @see WebDriver.Window#setPosition(Point)
      * @since 2.0
      */
-    public Browser setPosition(int x, int y) {
+    public void setPosition(int x, int y) {
         ActionTemplate.browser(browser())
             .execute(browser -> getWindowManager(browser).setPosition(new Point(x, y)))
             .fireEvent(browser -> new SetWindowPositionEvent(x, y));
         log.debug("set position of current window ({}) to x={} and y={}", getHandle(), x, y);
-        return browser();
     }
 
     /**
@@ -131,16 +123,14 @@ public class Window extends BaseBrowserOperation {
      *
      * @param width the new width of the window
      * @param height the new height of the window
-     * @return the original browser of this operation
      * @see WebDriver.Window#setSize(Dimension)
      * @since 2.0
      */
-    public Browser setSize(int width, int height) {
+    public void setSize(int width, int height) {
         ActionTemplate.browser(browser())
             .execute(browser -> getWindowManager(browser).setSize(new Dimension(width, height)))
             .fireEvent(browser -> new SetWindowSizeEvent(width, height));
         log.debug("set size of current window ({}) to width={} and height={}", getHandle(), width, height);
-        return browser();
     }
 
     /**
@@ -151,30 +141,26 @@ public class Window extends BaseBrowserOperation {
      * See <a href="https://developer.mozilla.org/en/docs/Web/API/Element/scrollIntoView">MDN Web API</a> for details.
      *
      * @param fragment the fragment to scroll into view
-     * @return the original browser of this operation
-     * @see JavaScript
+     * @see JavaScriptExecutor
      * @since 2.0
      */
-    public Browser scrollTo(PageFragment fragment) {
+    public void scrollTo(PageFragment fragment) {
         log.debug("scrolling [{}] into view", fragment.getName().orElse(fragment.toString()));
-        return browser().javaScript().execute("arguments[0].scrollIntoView(true)", fragment);
+        browser().javaScript().execute("arguments[0].scrollIntoView(true)", fragment);
     }
 
     /**
      * Closes the currently focused window. If that window was the last open window, the browser wil be closed as well
      * making it unusable in the future. Use this method with care!
      *
-     * @return the original browser of this operation
      * @see WebDriver#close()
      * @since 2.0
      */
-    public Browser close() {
+    public void close() {
         log.debug("closing current window ({})", getHandle());
-        ActionTemplate.browser(browser()).execute(browser -> {
-            browser.webDriver().close();
-            browser.webDriver().switchTo().defaultContent();
-        }).fireEvent(browser -> new ClosedWindowEvent());
-        return browser();
+        ActionTemplate.browser(browser())
+            .execute(browser -> browser.webDriver().close())
+            .fireEvent(browser -> new ClosedWindowEvent());
     }
 
     private WebDriver.Window getWindowManager(Browser browser) {

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/browser/operations/FocusSetter.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/browser/operations/FocusSetter.java
@@ -24,15 +24,15 @@ import info.novatec.testit.webtester.internal.ActionTemplate;
  * @since 2.0
  */
 @Slf4j
-public class Focus extends BaseBrowserOperation {
+public class FocusSetter extends BaseBrowserOperation {
 
     /**
-     * Creates a new {@link Focus} for the given {@link Browser}.
+     * Creates a new {@link FocusSetter} for the given {@link Browser}.
      *
      * @param browser the browser to use
      * @since 2.0
      */
-    public Focus(Browser browser) {
+    public FocusSetter(Browser browser) {
         super(browser);
     }
 
@@ -40,17 +40,15 @@ public class Focus extends BaseBrowserOperation {
      * Sets the browser's focus to the frame with the given index.
      *
      * @param index the index of the frame to focus on
-     * @return the original browser of this operation
      * @throws NoSuchFrameException in case there is no frame with the given index
      * @see WebDriver.TargetLocator#frame(int)
      * @since 2.0
      */
-    public Browser onFrame(int index) throws NoSuchFrameException {
+    public void onFrame(int index) throws NoSuchFrameException {
         ActionTemplate.browser(browser())
             .execute(browser -> doOnFrame(browser, index))
             .fireEvent(browser -> new SwitchedToFrameEvent(index));
         log.debug("focused on frame with index: {}", index);
-        return browser();
     }
 
     private WebDriver doOnFrame(Browser browser, int index) {
@@ -61,17 +59,15 @@ public class Focus extends BaseBrowserOperation {
      * Sets the browser's focus to the frame with the given name or ID.
      *
      * @param nameOrId the name or ID of the frame to focus on
-     * @return the original browser of this operation
      * @throws NoSuchFrameException in case there is no frame with the given name or ID
      * @see WebDriver.TargetLocator#frame(String)
      * @since 2.0
      */
-    public Browser onFrame(String nameOrId) throws NoSuchFrameException {
+    public void onFrame(String nameOrId) throws NoSuchFrameException {
         ActionTemplate.browser(browser())
             .execute(browser -> doOnFrame(browser, nameOrId))
             .fireEvent(browser -> new SwitchedToFrameEvent(nameOrId));
         log.debug("focused on frame with name or ID: {}", nameOrId);
-        return browser();
     }
 
     private WebDriver doOnFrame(Browser browser, String nameOrId) {
@@ -82,17 +78,15 @@ public class Focus extends BaseBrowserOperation {
      * Sets the browser's focus to the frame of the given {@link PageFragment page fragment}.
      *
      * @param frame the page fragment representing the frame to focus on
-     * @return the original browser of this operation
      * @throws NoSuchFrameException in case there is no frame with the given name or ID
      * @see WebDriver.TargetLocator#frame(String)
      * @since 2.0
      */
-    public Browser onFrame(PageFragment frame) throws NoSuchFrameException {
+    public void onFrame(PageFragment frame) throws NoSuchFrameException {
         ActionTemplate.browser(browser())
             .execute(browser -> doOnFrame(browser, frame))
             .fireEvent(browser -> new SwitchedToFrameEvent(frame));
         log.debug("focused on frame page fragment: {}", frame);
-        return browser();
     }
 
     private WebDriver doOnFrame(Browser browser, PageFragment frame) {
@@ -102,22 +96,20 @@ public class Focus extends BaseBrowserOperation {
     /**
      * Sets the browser's focus to the window with the given name or handle.
      * <p>
-     * <b>Tip:</b> A handle for the current window can be got by using the {@link Window#getHandle()} method.
+     * <b>Tip:</b> A handle for the current window can be got by using the {@link CurrentWindow#getHandle()} method.
      *
      * @param nameOrHandle the name or handle of the window to focus on
-     * @return the original browser of this operation
      * @throws NoSuchWindowException in case there is no window with the given name or handle
      * @see Browser#currentWindow()
-     * @see Window#getHandle()
+     * @see CurrentWindow#getHandle()
      * @see WebDriver.TargetLocator#window(String)
      * @since 2.0
      */
-    public Browser onWindow(String nameOrHandle) throws NoSuchWindowException {
+    public void onWindow(String nameOrHandle) throws NoSuchWindowException {
         ActionTemplate.browser(browser())
             .execute(browser -> doOnWindow(browser, nameOrHandle))
             .fireEvent(browser -> new SwitchedToWindowEvent(nameOrHandle));
         log.debug("focused on window with name or handle: {}", nameOrHandle);
-        return browser();
     }
 
     private void doOnWindow(Browser browser, String nameOrHandle) {
@@ -128,16 +120,14 @@ public class Focus extends BaseBrowserOperation {
      * Sets the browser's focus to the default content.
      * This is either the first frame or the main content (in case of IFrames).
      *
-     * @return the original browser of this operation
      * @see WebDriver.TargetLocator#defaultContent()
      * @since 2.0
      */
-    public Browser onDefaultContent() {
+    public void onDefaultContent() {
         ActionTemplate.browser(browser())
             .execute(this::doOnDefaultContent)
             .fireEvent(browser -> new SwitchedToDefaultContentEvent());
         log.debug("focused on default content");
-        return browser();
     }
 
     private void doOnDefaultContent(Browser browser) {

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/browser/operations/JavaScriptExecutor.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/browser/operations/JavaScriptExecutor.java
@@ -13,15 +13,15 @@ import info.novatec.testit.webtester.pagefragments.PageFragment;
  * @see #execute(String, PageFragment, Object...)
  * @since 2.0
  */
-public class JavaScript extends BaseBrowserOperation {
+public class JavaScriptExecutor extends BaseBrowserOperation {
 
     /**
-     * Creates a new {@link JavaScript} for the given {@link Browser}.
+     * Creates a new {@link JavaScriptExecutor} for the given {@link Browser}.
      *
      * @param browser the browser to use
      * @since 2.0
      */
-    public JavaScript(Browser browser) {
+    public JavaScriptExecutor(Browser browser) {
         super(browser);
     }
 
@@ -33,13 +33,11 @@ public class JavaScript extends BaseBrowserOperation {
      * @param script the JavaScript code to be executed on the current page
      * @param fragment the target {@link PageFragment}
      * @param parameters any of Boolean, Long, String, List, WebElement or null.
-     * @return the original browser of this operation
      * @see JavascriptExecutor#executeScript(String, Object...)
      * @since 2.0
      */
-    public Browser execute(String script, PageFragment fragment, Object... parameters) {
+    public void execute(String script, PageFragment fragment, Object... parameters) {
         executeWithReturn(script, fragment, parameters);
-        return browser();
     }
 
     /**
@@ -67,13 +65,11 @@ public class JavaScript extends BaseBrowserOperation {
      *
      * @param script the JavaScript code to be executed on the current page
      * @param parameters any of Boolean, Long, String, List, WebElement or null.
-     * @return the original browser of this operation
      * @see JavascriptExecutor#executeScript(String, Object...)
      * @since 2.0
      */
-    public Browser execute(String script, Object... parameters) {
+    public void execute(String script, Object... parameters) {
         executeWithReturn(script, parameters);
-        return browser();
     }
 
     /**

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/browser/operations/Navigator.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/browser/operations/Navigator.java
@@ -20,15 +20,15 @@ import info.novatec.testit.webtester.internal.ActionTemplate;
  * @since 2.0
  */
 @Slf4j
-public class Navigate extends BaseBrowserOperation {
+public class Navigator extends BaseBrowserOperation {
 
     /**
-     * Creates a new {@link Navigate} for the given {@link Browser}.
+     * Creates a new {@link Navigator} for the given {@link Browser}.
      *
      * @param browser the browser to use
      * @since 2.0
      */
-    public Navigate(Browser browser) {
+    public Navigator(Browser browser) {
         super(browser);
     }
 
@@ -36,60 +36,52 @@ public class Navigate extends BaseBrowserOperation {
      * Navigates backwards in the {@link Browser} history N times.
      *
      * @param times the number of times the backwards navigation should be executed
-     * @return the original browser of this operation
      * @see #backwards()
      * @see WebDriver.Navigation#back()
      * @since 2.0
      */
-    public Browser backwards(int times) {
+    public void backwards(int times) {
         IntStream.range(0, times).forEach(i -> backwards());
-        return browser();
     }
 
     /**
      * Navigates backwards in the {@link Browser} history. If there is no history
      * available, this method will do nothing.
      *
-     * @return the original browser of this operation
      * @see WebDriver.Navigation#back()
      * @since 2.0
      */
-    public Browser backwards() {
+    public void backwards() {
         ActionTemplate.browser(browser())
             .execute(browser -> browser.webDriver().navigate().back())
             .fireEvent(browser -> new NavigatedBackwardsEvent());
         log.debug("navigated backwards in browser history");
-        return browser();
     }
 
     /**
      * Navigates forwards in the {@link Browser} history N times.
      *
      * @param times the number of times the forwards navigation should be executed
-     * @return the original browser of this operation
      * @see #forwards()
      * @see WebDriver.Navigation#forward()
      * @since 2.0
      */
-    public Browser forwards(int times) {
+    public void forwards(int times) {
         IntStream.range(0, times).forEach(i -> forwards());
-        return browser();
     }
 
     /**
      * Navigates forwards in the {@link Browser} history. If there is no forward
      * page available, this method will do nothing.
      *
-     * @return the original browser of this operation
      * @see WebDriver.Navigation#forward()
      * @since 2.0
      */
-    public Browser forwards() {
+    public void forwards() {
         ActionTemplate.browser(browser())
             .execute(browser -> browser.webDriver().navigate().forward())
             .fireEvent(browser -> new NavigatedForwardsEvent());
         log.debug("navigated forwards in browser history");
-        return browser();
     }
 
 }

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/browser/operations/PageSourceSaver.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/browser/operations/PageSourceSaver.java
@@ -32,15 +32,15 @@ import info.novatec.testit.webtester.events.browser.SavedSourceCodeEvent;
  * @since 2.0
  */
 @Slf4j
-public class PageSource extends BaseBrowserOperation {
+public class PageSourceSaver extends BaseBrowserOperation {
 
     /**
-     * Creates a new {@link PageSource} for the given {@link Browser}.
+     * Creates a new {@link PageSourceSaver} for the given {@link Browser}.
      *
      * @param browser the browser to use
      * @since 2.0
      */
-    public PageSource(Browser browser) {
+    public PageSourceSaver(Browser browser) {
         super(browser);
     }
 

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/browser/operations/ScreenshotTaker.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/browser/operations/ScreenshotTaker.java
@@ -36,15 +36,15 @@ import info.novatec.testit.webtester.events.browser.TookScreenshotEvent;
  * @since 2.0
  */
 @Slf4j
-public class Screenshot extends BaseBrowserOperation {
+public class ScreenshotTaker extends BaseBrowserOperation {
 
     /**
-     * Creates a new {@link Screenshot} for the given {@link Browser}.
+     * Creates a new {@link ScreenshotTaker} for the given {@link Browser}.
      *
      * @param browser the browser to use
      * @since 2.0
      */
-    public Screenshot(Browser browser) {
+    public ScreenshotTaker(Browser browser) {
         super(browser);
     }
 

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/browser/operations/UrlOpener.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/browser/operations/UrlOpener.java
@@ -25,30 +25,29 @@ import info.novatec.testit.webtester.internal.ActionTemplate;
  * @since 2.0
  */
 @Slf4j
-public class Open extends BaseBrowserOperation {
+public class UrlOpener extends BaseBrowserOperation {
 
     /**
-     * Creates a new {@link Open} for the given {@link Browser}.
+     * Creates a new {@link UrlOpener} for the given {@link Browser}.
      *
      * @param browser the browser to use
      * @since 2.0
      */
-    public Open(Browser browser) {
+    public UrlOpener(Browser browser) {
         super(browser);
     }
 
     /**
      * Navigates to the default entry point configured in {@link Configuration#getDefaultEntryPoint()}.
      *
-     * @return the original browser of this operation
      * @see org.openqa.selenium.WebDriver#get(String)
      * @since 2.0
      */
-    public Browser defaultEntryPoint() {
+    public void defaultEntryPoint() {
         String entryPoint = configuration().getDefaultEntryPoint()
             .filter(StringUtils::isNotBlank)
             .orElseThrow(() -> new IllegalStateException("no default entry point defined"));
-        return url(entryPoint);
+        url(entryPoint);
     }
 
     /**
@@ -62,7 +61,8 @@ public class Open extends BaseBrowserOperation {
      * @since 2.0
      */
     public <T extends Page> T defaultEntryPoint(Class<T> pageClass) {
-        return defaultEntryPoint().create(pageClass);
+        defaultEntryPoint();
+        return browser().create(pageClass);
     }
 
     /**
@@ -76,7 +76,8 @@ public class Open extends BaseBrowserOperation {
      * @since 2.0
      */
     public <T extends Page> T url(URL url, Class<T> pageClass) {
-        return url(url).create(pageClass);
+        url(url);
+        return browser().create(pageClass);
     }
 
     /**
@@ -90,35 +91,33 @@ public class Open extends BaseBrowserOperation {
      * @since 2.0
      */
     public <T extends Page> T url(String url, Class<T> pageClass) {
-        return url(url).create(pageClass);
+        url(url);
+        return browser().create(pageClass);
     }
 
     /**
      * Navigates to the given url.
      *
      * @param url the URL to open
-     * @return the original browser of this operation
      * @see org.openqa.selenium.WebDriver#get(String)
      * @since 2.0
      */
-    public Browser url(URL url) {
-        return url(url.toString());
+    public void url(URL url) {
+        url(url.toString());
     }
 
     /**
      * Navigates to the given url.
      *
      * @param url the URL to open
-     * @return the original browser of this operation
      * @see org.openqa.selenium.WebDriver#get(String)
      * @since 2.0
      */
-    public Browser url(String url) {
+    public void url(String url) {
         ActionTemplate.browser(browser())
             .execute(browser -> webDriver().get(url))
             .fireEvent(browser -> new OpenedUrlEvent(url));
         log.debug("opened URL: {}", url);
-        return browser();
     }
 
 }

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/events/browser/ClosedWindowEvent.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/events/browser/ClosedWindowEvent.java
@@ -1,6 +1,6 @@
 package info.novatec.testit.webtester.events.browser;
 
-import info.novatec.testit.webtester.browser.operations.Window;
+import info.novatec.testit.webtester.browser.operations.CurrentWindow;
 import info.novatec.testit.webtester.events.Event;
 import info.novatec.testit.webtester.events.EventListener;
 import info.novatec.testit.webtester.events.EventSystem;
@@ -13,7 +13,7 @@ import info.novatec.testit.webtester.events.AbstractEvent;
  * @see Event
  * @see EventListener
  * @see EventSystem
- * @see Window#close()
+ * @see CurrentWindow#close()
  * @since 2.0
  */
 @SuppressWarnings("serial")

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/events/browser/MaximizedWindowEvent.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/events/browser/MaximizedWindowEvent.java
@@ -1,6 +1,6 @@
 package info.novatec.testit.webtester.events.browser;
 
-import info.novatec.testit.webtester.browser.operations.Window;
+import info.novatec.testit.webtester.browser.operations.CurrentWindow;
 import info.novatec.testit.webtester.events.Event;
 import info.novatec.testit.webtester.events.EventListener;
 import info.novatec.testit.webtester.events.EventSystem;
@@ -13,7 +13,7 @@ import info.novatec.testit.webtester.events.AbstractEvent;
  * @see Event
  * @see EventListener
  * @see EventSystem
- * @see Window#maximize()
+ * @see CurrentWindow#maximize()
  * @since 2.0
  */
 @SuppressWarnings("serial")

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/events/browser/NavigatedBackwardsEvent.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/events/browser/NavigatedBackwardsEvent.java
@@ -1,6 +1,6 @@
 package info.novatec.testit.webtester.events.browser;
 
-import info.novatec.testit.webtester.browser.operations.Navigate;
+import info.novatec.testit.webtester.browser.operations.Navigator;
 import info.novatec.testit.webtester.events.Event;
 import info.novatec.testit.webtester.events.EventListener;
 import info.novatec.testit.webtester.events.EventSystem;
@@ -13,8 +13,8 @@ import info.novatec.testit.webtester.events.AbstractEvent;
  * @see Event
  * @see EventListener
  * @see EventSystem
- * @see Navigate#backwards()
- * @see Navigate#backwards(int)
+ * @see Navigator#backwards()
+ * @see Navigator#backwards(int)
  * @since 2.0
  */
 @SuppressWarnings("serial")

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/events/browser/NavigatedForwardsEvent.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/events/browser/NavigatedForwardsEvent.java
@@ -1,6 +1,6 @@
 package info.novatec.testit.webtester.events.browser;
 
-import info.novatec.testit.webtester.browser.operations.Navigate;
+import info.novatec.testit.webtester.browser.operations.Navigator;
 import info.novatec.testit.webtester.events.Event;
 import info.novatec.testit.webtester.events.EventListener;
 import info.novatec.testit.webtester.events.EventSystem;
@@ -13,8 +13,8 @@ import info.novatec.testit.webtester.events.AbstractEvent;
  * @see Event
  * @see EventListener
  * @see EventSystem
- * @see Navigate#forwards()
- * @see Navigate#forwards(int)
+ * @see Navigator#forwards()
+ * @see Navigator#forwards(int)
  * @since 2.0
  */
 @SuppressWarnings("serial")

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/events/browser/OpenedUrlEvent.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/events/browser/OpenedUrlEvent.java
@@ -6,7 +6,7 @@ import java.net.URL;
 
 import lombok.Getter;
 
-import info.novatec.testit.webtester.browser.operations.Open;
+import info.novatec.testit.webtester.browser.operations.UrlOpener;
 import info.novatec.testit.webtester.events.Event;
 import info.novatec.testit.webtester.events.EventListener;
 import info.novatec.testit.webtester.events.EventSystem;
@@ -21,12 +21,12 @@ import info.novatec.testit.webtester.events.AbstractEvent;
  * @see Event
  * @see EventListener
  * @see EventSystem
- * @see Open#url(String)
- * @see Open#url(URL)
- * @see Open#url(String, Class)
- * @see Open#url(URL, Class)
- * @see Open#defaultEntryPoint()
- * @see Open#defaultEntryPoint(Class)
+ * @see UrlOpener#url(String)
+ * @see UrlOpener#url(URL)
+ * @see UrlOpener#url(String, Class)
+ * @see UrlOpener#url(URL, Class)
+ * @see UrlOpener#defaultEntryPoint()
+ * @see UrlOpener#defaultEntryPoint(Class)
  * @since 2.0
  */
 @SuppressWarnings("serial")

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/events/browser/RefreshedPageEvent.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/events/browser/RefreshedPageEvent.java
@@ -1,6 +1,6 @@
 package info.novatec.testit.webtester.events.browser;
 
-import info.novatec.testit.webtester.browser.operations.Window;
+import info.novatec.testit.webtester.browser.operations.CurrentWindow;
 import info.novatec.testit.webtester.events.Event;
 import info.novatec.testit.webtester.events.EventListener;
 import info.novatec.testit.webtester.events.EventSystem;
@@ -13,7 +13,7 @@ import info.novatec.testit.webtester.events.AbstractEvent;
  * @see Event
  * @see EventListener
  * @see EventSystem
- * @see Window#refresh()
+ * @see CurrentWindow#refresh()
  * @since 2.0
  */
 @SuppressWarnings("serial")

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/events/browser/SavedSourceCodeEvent.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/events/browser/SavedSourceCodeEvent.java
@@ -7,7 +7,7 @@ import java.nio.file.Path;
 
 import lombok.Getter;
 
-import info.novatec.testit.webtester.browser.operations.PageSource;
+import info.novatec.testit.webtester.browser.operations.PageSourceSaver;
 import info.novatec.testit.webtester.events.Event;
 import info.novatec.testit.webtester.events.EventListener;
 import info.novatec.testit.webtester.events.EventSystem;
@@ -22,13 +22,13 @@ import info.novatec.testit.webtester.events.AbstractEvent;
  * @see Event
  * @see EventListener
  * @see EventSystem
- * @see PageSource#save()
- * @see PageSource#save(String, String)
- * @see PageSource#save(Path, String)
- * @see PageSource#save(File, String)
- * @see PageSource#save(String)
- * @see PageSource#save(Path)
- * @see PageSource#save(File)
+ * @see PageSourceSaver#save()
+ * @see PageSourceSaver#save(String, String)
+ * @see PageSourceSaver#save(Path, String)
+ * @see PageSourceSaver#save(File, String)
+ * @see PageSourceSaver#save(String)
+ * @see PageSourceSaver#save(Path)
+ * @see PageSourceSaver#save(File)
  * @since 2.0
  */
 @SuppressWarnings("serial")

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/events/browser/SetWindowPositionEvent.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/events/browser/SetWindowPositionEvent.java
@@ -2,7 +2,7 @@ package info.novatec.testit.webtester.events.browser;
 
 import lombok.Getter;
 
-import info.novatec.testit.webtester.browser.operations.Window;
+import info.novatec.testit.webtester.browser.operations.CurrentWindow;
 import info.novatec.testit.webtester.events.AbstractEvent;
 import info.novatec.testit.webtester.events.Event;
 import info.novatec.testit.webtester.events.EventListener;
@@ -15,7 +15,7 @@ import info.novatec.testit.webtester.events.EventSystem;
  * @see Event
  * @see EventListener
  * @see EventSystem
- * @see Window#setPosition(int, int)
+ * @see CurrentWindow#setPosition(int, int)
  * @since 2.0
  */
 @Getter

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/events/browser/SetWindowSizeEvent.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/events/browser/SetWindowSizeEvent.java
@@ -2,7 +2,7 @@ package info.novatec.testit.webtester.events.browser;
 
 import lombok.Getter;
 
-import info.novatec.testit.webtester.browser.operations.Window;
+import info.novatec.testit.webtester.browser.operations.CurrentWindow;
 import info.novatec.testit.webtester.events.AbstractEvent;
 import info.novatec.testit.webtester.events.Event;
 import info.novatec.testit.webtester.events.EventListener;
@@ -15,7 +15,7 @@ import info.novatec.testit.webtester.events.EventSystem;
  * @see Event
  * @see EventListener
  * @see EventSystem
- * @see Window#setSize(int, int)
+ * @see CurrentWindow#setSize(int, int)
  * @since 2.0
  */
 @Getter

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/events/browser/SwitchedToDefaultContentEvent.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/events/browser/SwitchedToDefaultContentEvent.java
@@ -1,6 +1,6 @@
 package info.novatec.testit.webtester.events.browser;
 
-import info.novatec.testit.webtester.browser.operations.Focus;
+import info.novatec.testit.webtester.browser.operations.FocusSetter;
 import info.novatec.testit.webtester.events.Event;
 import info.novatec.testit.webtester.events.EventListener;
 import info.novatec.testit.webtester.events.EventSystem;
@@ -13,7 +13,7 @@ import info.novatec.testit.webtester.events.AbstractEvent;
  * @see Event
  * @see EventListener
  * @see EventSystem
- * @see Focus#onDefaultContent()
+ * @see FocusSetter#onDefaultContent()
  * @since 2.0
  */
 @SuppressWarnings("serial")

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/events/browser/SwitchedToFrameEvent.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/events/browser/SwitchedToFrameEvent.java
@@ -4,7 +4,7 @@ import static java.lang.String.format;
 
 import lombok.Getter;
 
-import info.novatec.testit.webtester.browser.operations.Focus;
+import info.novatec.testit.webtester.browser.operations.FocusSetter;
 import info.novatec.testit.webtester.events.Event;
 import info.novatec.testit.webtester.events.EventListener;
 import info.novatec.testit.webtester.events.EventSystem;
@@ -20,9 +20,9 @@ import info.novatec.testit.webtester.pagefragments.PageFragment;
  * @see Event
  * @see EventListener
  * @see EventSystem
- * @see Focus#onFrame(int)
- * @see Focus#onFrame(String)
- * @see Focus#onFrame(PageFragment)
+ * @see FocusSetter#onFrame(int)
+ * @see FocusSetter#onFrame(String)
+ * @see FocusSetter#onFrame(PageFragment)
  * @since 2.0
  */
 @SuppressWarnings("serial")

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/events/browser/SwitchedToWindowEvent.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/events/browser/SwitchedToWindowEvent.java
@@ -4,7 +4,7 @@ import static java.lang.String.format;
 
 import lombok.Getter;
 
-import info.novatec.testit.webtester.browser.operations.Focus;
+import info.novatec.testit.webtester.browser.operations.FocusSetter;
 import info.novatec.testit.webtester.events.Event;
 import info.novatec.testit.webtester.events.EventListener;
 import info.novatec.testit.webtester.events.EventSystem;
@@ -19,7 +19,7 @@ import info.novatec.testit.webtester.events.AbstractEvent;
  * @see Event
  * @see EventListener
  * @see EventSystem
- * @see Focus#onWindow(String)
+ * @see FocusSetter#onWindow(String)
  * @since 2.0
  */
 @SuppressWarnings("serial")

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/events/browser/TookScreenshotEvent.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/events/browser/TookScreenshotEvent.java
@@ -7,7 +7,7 @@ import java.nio.file.Path;
 
 import lombok.Getter;
 
-import info.novatec.testit.webtester.browser.operations.Screenshot;
+import info.novatec.testit.webtester.browser.operations.ScreenshotTaker;
 import info.novatec.testit.webtester.events.Event;
 import info.novatec.testit.webtester.events.EventListener;
 import info.novatec.testit.webtester.events.EventSystem;
@@ -22,13 +22,13 @@ import info.novatec.testit.webtester.events.AbstractEvent;
  * @see Event
  * @see EventListener
  * @see EventSystem
- * @see Screenshot#takeAndStore()
- * @see Screenshot#takeAndStore(String)
- * @see Screenshot#takeAndStore(Path)
- * @see Screenshot#takeAndStore(File)
- * @see Screenshot#takeAndStore(String, String)
- * @see Screenshot#takeAndStore(Path, String)
- * @see Screenshot#takeAndStore(File, String)
+ * @see ScreenshotTaker#takeAndStore()
+ * @see ScreenshotTaker#takeAndStore(String)
+ * @see ScreenshotTaker#takeAndStore(Path)
+ * @see ScreenshotTaker#takeAndStore(File)
+ * @see ScreenshotTaker#takeAndStore(String, String)
+ * @see ScreenshotTaker#takeAndStore(Path, String)
+ * @see ScreenshotTaker#takeAndStore(File, String)
  * @since 2.0
  */
 @SuppressWarnings("serial")

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/pagefragments/PageFragment.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/pagefragments/PageFragment.java
@@ -8,7 +8,7 @@ import org.openqa.selenium.WebElement;
 
 import info.novatec.testit.webtester.adhoc.AdHocFinder;
 import info.novatec.testit.webtester.browser.Browser;
-import info.novatec.testit.webtester.browser.operations.JavaScript;
+import info.novatec.testit.webtester.browser.operations.JavaScriptExecutor;
 import info.novatec.testit.webtester.internal.OffersAdHocFinding;
 import info.novatec.testit.webtester.internal.OffersBrowserGetter;
 import info.novatec.testit.webtester.internal.OffersPageCreation;
@@ -147,7 +147,7 @@ public interface PageFragment extends OffersBrowserGetter, OffersAdHocFinding, O
      * @param attributeName the name of the attribute to set
      * @param value the value to set the attribute to
      * @see PageFragment
-     * @see JavaScript
+     * @see JavaScriptExecutor
      * @since 2.0
      */
     default void setAttribute(String attributeName, String value) {

--- a/webtester-core/src/test/java/info/novatec/testit/webtester/browser/operations/CurrentWindowTest.java
+++ b/webtester-core/src/test/java/info/novatec/testit/webtester/browser/operations/CurrentWindowTest.java
@@ -2,7 +2,6 @@ package info.novatec.testit.webtester.browser.operations;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
@@ -10,7 +9,6 @@ import java.io.IOException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InOrder;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.Point;
@@ -29,15 +27,15 @@ import info.novatec.testit.webtester.events.browser.SetWindowSizeEvent;
 
 
 @RunWith(MockitoJUnitRunner.class)
-public class WindowTest {
+public class CurrentWindowTest {
 
     private WebDriver webDriver;
-    private Window cut;
+    private CurrentWindow cut;
 
     @Before
     public void init() throws IOException {
         webDriver = MockFactory.webDriver();
-        cut = new Window(WebDriverBrowser.forWebDriver(webDriver).build());
+        cut = new CurrentWindow(WebDriverBrowser.forWebDriver(webDriver).build());
     }
 
     /* window handle */
@@ -122,9 +120,7 @@ public class WindowTest {
     @Test
     public void closingWindowDelegatesToCorrectWebDriverMethods() {
         cut.close();
-        InOrder inOrder = inOrder(webDriver, targetLocator());
-        inOrder.verify(webDriver).close();
-        inOrder.verify(targetLocator()).defaultContent();
+        verify(webDriver).close();
     }
 
     @Test

--- a/webtester-core/src/test/java/info/novatec/testit/webtester/browser/operations/FocusSetterTest.java
+++ b/webtester-core/src/test/java/info/novatec/testit/webtester/browser/operations/FocusSetterTest.java
@@ -35,7 +35,7 @@ import info.novatec.testit.webtester.pagefragments.PageFragment;
 
 
 @RunWith(MockitoJUnitRunner.class)
-public class FocusTest {
+public class FocusSetterTest {
 
     private static final int INDEX = 42;
     private static final String NAME_OR_ID = "fooBar";
@@ -50,7 +50,7 @@ public class FocusTest {
 
     Browser browser;
     EventSystem eventSystem;
-    Focus cut;
+    FocusSetter cut;
 
     @Before
     public void init() throws IOException {
@@ -58,7 +58,7 @@ public class FocusTest {
         doReturn(true).when(configuration).isEventSystemEnabled();
         browser = WebDriverBrowser.forWebDriver(webDriver).withConfiguration(configuration).build();
         eventSystem = browser.events();
-        cut = new Focus(browser);
+        cut = new FocusSetter(browser);
     }
 
     /* focusing on frame by index */

--- a/webtester-core/src/test/java/info/novatec/testit/webtester/browser/operations/JavaScriptExecutorTest.java
+++ b/webtester-core/src/test/java/info/novatec/testit/webtester/browser/operations/JavaScriptExecutorTest.java
@@ -18,7 +18,7 @@ import info.novatec.testit.webtester.pagefragments.PageFragment;
 
 
 @RunWith(MockitoJUnitRunner.class)
-public class JavaScriptTest {
+public class JavaScriptExecutorTest {
 
     static final String JAVA_SCRIPT = "alert('Hello World!')";
 
@@ -34,13 +34,6 @@ public class JavaScriptTest {
         WebDriver webDriver = javaScriptExecutingWebDriver();
         javaScriptFor(webDriver).execute(JAVA_SCRIPT, "param1", "param2");
         verify(( JavascriptExecutor ) webDriver).executeScript(JAVA_SCRIPT, "param1", "param2");
-    }
-
-    @Test
-    public void justParametersWithoutReturnReturnsBrowser() {
-        Browser browser = browserFor(javaScriptExecutingWebDriver());
-        Browser returnBrowser = new JavaScript(browser).execute(JAVA_SCRIPT, "param");
-        assertThat(returnBrowser).isSameAs(browser);
     }
 
     @Test
@@ -65,13 +58,6 @@ public class JavaScriptTest {
     }
 
     @Test
-    public void pageFragmentAndParametersWithoutReturnReturnsBrowser() {
-        Browser browser = browserFor(javaScriptExecutingWebDriver());
-        Browser returnBrowser = new JavaScript(browser).execute(JAVA_SCRIPT, pageFragment(), "param");
-        assertThat(returnBrowser).isSameAs(browser);
-    }
-
-    @Test
     public void pageFragmentAndParametersWithReturn() {
 
         WebDriver webDriver = javaScriptExecutingWebDriver();
@@ -93,8 +79,8 @@ public class JavaScriptTest {
 
     /* utilities */
 
-    JavaScript javaScriptFor(WebDriver webDriver) {
-        return new JavaScript(browserFor(webDriver));
+    JavaScriptExecutor javaScriptFor(WebDriver webDriver) {
+        return new JavaScriptExecutor(browserFor(webDriver));
     }
 
     Browser browserFor(WebDriver webDriver) {

--- a/webtester-core/src/test/java/info/novatec/testit/webtester/browser/operations/NavigatorTest.java
+++ b/webtester-core/src/test/java/info/novatec/testit/webtester/browser/operations/NavigatorTest.java
@@ -24,7 +24,7 @@ import info.novatec.testit.webtester.events.browser.NavigatedForwardsEvent;
 
 
 @RunWith(MockitoJUnitRunner.class)
-public class NavigateTest {
+public class NavigatorTest {
 
     @Mock
     WebDriver webDriver;
@@ -33,14 +33,14 @@ public class NavigateTest {
 
     Browser browser;
     EventSystem eventSystem;
-    Navigate cut;
+    Navigator cut;
 
     @Before
     public void init() throws IOException {
         doReturn(navigation).when(webDriver).navigate();
         browser = WebDriverBrowser.forWebDriver(webDriver).build();
         eventSystem = browser.events();
-        cut = new Navigate(browser);
+        cut = new Navigator(browser);
     }
 
     /* forwards */

--- a/webtester-core/src/test/java/info/novatec/testit/webtester/browser/operations/ScreenshotTakerTest.java
+++ b/webtester-core/src/test/java/info/novatec/testit/webtester/browser/operations/ScreenshotTakerTest.java
@@ -11,16 +11,18 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.openqa.selenium.WebDriver;
 
+import integration.browser.operations.ScreenshotTakerIntegrationTest;
+
 import info.novatec.testit.webtester.browser.Browser;
 import info.novatec.testit.webtester.browser.WebDriverBrowser;
 
 
 /**
  * Since taking screenshots is a very complex (in the sense of involved classes and systems) operation this class is mainly
- * integration tests by {@link integration.browser.operations.ScreenshotIntegrationTest}.
+ * integration tests by {@link ScreenshotTakerIntegrationTest}.
  */
 @RunWith(MockitoJUnitRunner.class)
-public class ScreenshotTest {
+public class ScreenshotTakerTest {
 
     @Mock
     WebDriver webDriver;
@@ -29,7 +31,7 @@ public class ScreenshotTest {
     public void takingScreenshotWithUnsupportedWebDriverReturnsEmptyOptional() {
 
         Browser browser = WebDriverBrowser.buildForWebDriver(webDriver);
-        Screenshot cut = new Screenshot(browser);
+        ScreenshotTaker cut = new ScreenshotTaker(browser);
 
         Optional<File> file = cut.takeAndStore();
         assertThat(file).isEmpty();

--- a/webtester-core/src/test/java/info/novatec/testit/webtester/browser/operations/UrlOpenerTest.java
+++ b/webtester-core/src/test/java/info/novatec/testit/webtester/browser/operations/UrlOpenerTest.java
@@ -33,7 +33,7 @@ import info.novatec.testit.webtester.pages.Page;
 
 
 @RunWith(MockitoJUnitRunner.class)
-public class OpenTest {
+public class UrlOpenerTest {
 
     static final String URL = "http://www.examples.com";
     static final URL URL_OBJECT = TestUtils.toUrl(URL);
@@ -48,7 +48,7 @@ public class OpenTest {
 
     EventSystem eventSystem;
 
-    Open cut;
+    UrlOpener cut;
 
     @Before
     public void init() {
@@ -64,7 +64,7 @@ public class OpenTest {
 
         doReturn(true).when(configuration).isEventSystemEnabled();
 
-        cut = new Open(browser);
+        cut = new UrlOpener(browser);
 
         setDefaultEntryPoint(URL);
 
@@ -171,24 +171,24 @@ public class OpenTest {
 
     /* method execution */
 
-    Browser executeDefaultEntryPoint() {
-        return cut.defaultEntryPoint();
+    void executeDefaultEntryPoint() {
+        cut.defaultEntryPoint();
     }
 
     Page executeDefaultEntryPointWithPage() {
         return cut.defaultEntryPoint(Page.class);
     }
 
-    Browser executeUrlObject() {
-        return cut.url(URL_OBJECT);
+    void executeUrlObject() {
+        cut.url(URL_OBJECT);
     }
 
     Page executeUrlObjectWithPage() {
         return cut.url(URL_OBJECT, Page.class);
     }
 
-    Browser executeUrlString() {
-        return cut.url(URL);
+    void executeUrlString() {
+        cut.url(URL);
     }
 
     Page executeUrlStringWithPage() {

--- a/webtester-core/src/test/java/info/novatec/testit/webtester/css/StyleChangerImplTest.java
+++ b/webtester-core/src/test/java/info/novatec/testit/webtester/css/StyleChangerImplTest.java
@@ -19,7 +19,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.openqa.selenium.WebDriverException;
 
 import info.novatec.testit.webtester.browser.Browser;
-import info.novatec.testit.webtester.browser.operations.JavaScript;
+import info.novatec.testit.webtester.browser.operations.JavaScriptExecutor;
 import info.novatec.testit.webtester.pagefragments.PageFragment;
 
 
@@ -31,7 +31,7 @@ public class StyleChangerImplTest {
     @Mock
     Browser browser;
     @Mock
-    JavaScript javaScript;
+    JavaScriptExecutor javaScript;
 
     @InjectMocks
     StyleChangerImpl cut;

--- a/webtester-core/src/test/java/integration/browser/operations/CurrentWindowIntegrationTest.java
+++ b/webtester-core/src/test/java/integration/browser/operations/CurrentWindowIntegrationTest.java
@@ -11,7 +11,7 @@ import info.novatec.testit.webtester.pagefragments.annotations.IdentifyUsing;
 import info.novatec.testit.webtester.pages.Page;
 
 
-public class WindowIntegrationTest extends BaseIntegrationTest {
+public class CurrentWindowIntegrationTest extends BaseIntegrationTest {
 
     @Override
     protected String getHTMLFilePath() {

--- a/webtester-core/src/test/java/integration/browser/operations/ScreenshotTakerIntegrationTest.java
+++ b/webtester-core/src/test/java/integration/browser/operations/ScreenshotTakerIntegrationTest.java
@@ -12,7 +12,7 @@ import org.junit.rules.TemporaryFolder;
 import integration.BaseIntegrationTest;
 
 
-public class ScreenshotIntegrationTest extends BaseIntegrationTest {
+public class ScreenshotTakerIntegrationTest extends BaseIntegrationTest {
 
     /**
      * Matches timestamp based file names like: 2016-01-03T10_15_30.201.png


### PR DESCRIPTION
- Names now reflect what the classes responsibilities are - getter methods on browser have not been changed since their names are based on API calls
- Instead of returning the linked Browser instance most operation methods now return void. The fluent API had some drawbacks which need to be addressed in future releases.
