### PR TITLE
Added escaping of values when using IdStartsWith and IdEndsWith ByProducers

### DIFF
--- a/webtester-core/src/main/java/info/novatec/testit/webtester/pagefragments/identification/CssSelectorUtils.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/pagefragments/identification/CssSelectorUtils.java
@@ -1,0 +1,44 @@
+package info.novatec.testit.webtester.pagefragments.identification;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+
+/**
+ * This class includes utility methods for working with CSS Selectors.
+ *
+ * @since 2.0.4
+ */
+public final class CssSelectorUtils {
+
+    /** These are all special characters in CSS who need escaping. */
+    private static final Character[] SPECIAL_CHARS =
+        { '!', '"', '#', '$', '%', '&', '\'', '(', ')', '*', '+', ',', '-', '.', '/', ':', ';', '<', '=', '>', '?', '@', '[',
+            '\\', ']', '^', '`', '{', '|', '}', '~' };
+    /** See {@link #SPECIAL_CHARS}. */
+    private static final Set<Character> SPECIAL_CHARS_SET = Arrays.stream(SPECIAL_CHARS).collect(Collectors.toSet());
+
+    /**
+     * Escape the given value by prefixing all {@link #SPECIAL_CHARS} with {@code \}.
+     * <p>
+     * This is necessary for all values used by CSS Selectors. For example when matching on the value of an attribute.
+     *
+     * @since 2.0.4
+     */
+    public static String escape(String value) {
+        StringBuilder escapedValue = new StringBuilder(value.length() * 2);
+        for (Character c : value.toCharArray()) {
+            if (SPECIAL_CHARS_SET.contains(c)) {
+                escapedValue.append('\\');
+            }
+            escapedValue.append(c);
+        }
+        return escapedValue.toString();
+    }
+
+    private CssSelectorUtils() {
+        // utility class
+    }
+
+}

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/pagefragments/identification/producers/CssSelector.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/pagefragments/identification/producers/CssSelector.java
@@ -7,6 +7,8 @@ import info.novatec.testit.webtester.pagefragments.identification.ByProducer;
 
 /**
  * This {@link ByProducer} produces a {@link By} using {@link By#cssSelector(String)}.
+ * <p>
+ * <b>Important:</b> Don't forget to escape special characters when using this selector!
  *
  * @see ByProducer
  * @since 2.0

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/pagefragments/identification/producers/IdEndsWith.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/pagefragments/identification/producers/IdEndsWith.java
@@ -3,11 +3,15 @@ package info.novatec.testit.webtester.pagefragments.identification.producers;
 import org.openqa.selenium.By;
 
 import info.novatec.testit.webtester.pagefragments.identification.ByProducer;
+import info.novatec.testit.webtester.pagefragments.identification.CssSelectorUtils;
 
 
 /**
  * This {@link ByProducer} produces a {@link By} using {@link By#cssSelector(String)} to partially match an ID
- * (ends-with).
+ * (ends-with). The given value will be escaped using {@link CssSelectorUtils#escape(String)} in order to prevent special
+ * characters from interfering with the selection.
+ * <p>
+ * <b>Example:</b> {@code :form:table:selection[5]} will be escaped to {@code \:form\:table\:selection\[5\]}
  *
  * @see ByProducer
  * @since 2.0
@@ -18,7 +22,8 @@ public class IdEndsWith implements ByProducer {
 
     @Override
     public By createBy(String value) {
-        return By.cssSelector(String.format(ID_ENDS_WITH_PATTERN, value));
+        String escapedValue = CssSelectorUtils.escape(value);
+        return By.cssSelector(String.format(ID_ENDS_WITH_PATTERN, escapedValue));
     }
 
     @Override

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/pagefragments/identification/producers/IdStartsWith.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/pagefragments/identification/producers/IdStartsWith.java
@@ -3,11 +3,15 @@ package info.novatec.testit.webtester.pagefragments.identification.producers;
 import org.openqa.selenium.By;
 
 import info.novatec.testit.webtester.pagefragments.identification.ByProducer;
+import info.novatec.testit.webtester.pagefragments.identification.CssSelectorUtils;
 
 
 /**
  * This {@link ByProducer} produces a {@link By} using {@link By#cssSelector(String)} to partially match an ID
- * (starts-with).
+ * (starts-with). The given value will be escaped using {@link CssSelectorUtils#escape(String)} in order to prevent special
+ * characters from interfering with the selection.
+ * <p>
+ * <b>Example:</b> {@code form:table:selection[5]} will be escaped to {@code form\:table\:selection\[5\]}
  *
  * @see ByProducer
  * @since 2.0
@@ -18,7 +22,8 @@ public class IdStartsWith implements ByProducer {
 
     @Override
     public By createBy(String value) {
-        return By.cssSelector(String.format(ID_STARTS_WITH_PATTERN, value));
+        String escapedValue = CssSelectorUtils.escape(value);
+        return By.cssSelector(String.format(ID_STARTS_WITH_PATTERN, escapedValue));
     }
 
     @Override

--- a/webtester-core/src/test/java/info/novatec/testit/webtester/pagefragments/identification/ByProducersTest.java
+++ b/webtester-core/src/test/java/info/novatec/testit/webtester/pagefragments/identification/ByProducersTest.java
@@ -45,7 +45,7 @@ public class ByProducersTest {
         public void producesCorrectBy() {
             By by = ByProducers.idEndsWith(":partial-id");
             assertThat(by).isInstanceOf(By.ByCssSelector.class);
-            assertThat(by).hasToString("By.cssSelector: [id$=':partial-id']");
+            assertThat(by).hasToString("By.cssSelector: [id$='\\:partial\\-id']");
         }
 
     }
@@ -56,7 +56,7 @@ public class ByProducersTest {
         public void producesCorrectBy() {
             By by = ByProducers.idStartsWith("partial-id:");
             assertThat(by).isInstanceOf(By.ByCssSelector.class);
-            assertThat(by).hasToString("By.cssSelector: [id^='partial-id:']");
+            assertThat(by).hasToString("By.cssSelector: [id^='partial\\-id\\:']");
         }
 
     }

--- a/webtester-core/src/test/java/info/novatec/testit/webtester/pagefragments/identification/CssSelectorUtilsTest.java
+++ b/webtester-core/src/test/java/info/novatec/testit/webtester/pagefragments/identification/CssSelectorUtilsTest.java
@@ -1,0 +1,53 @@
+package info.novatec.testit.webtester.pagefragments.identification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.Test;
+
+
+public class CssSelectorUtilsTest {
+
+    @Test
+    public void realisticExample() {
+        assertThat(CssSelectorUtils.escape("table:form:selection[0]")).isEqualTo("table\\:form\\:selection\\[0\\]");
+    }
+
+    @Test
+    public void allRelevantSpecialCharactersAreEscaped() {
+        SoftAssertions softly = new SoftAssertions();
+        softly.assertThat(CssSelectorUtils.escape("!")).isEqualTo("\\!");
+        softly.assertThat(CssSelectorUtils.escape("\"")).isEqualTo("\\\"");
+        softly.assertThat(CssSelectorUtils.escape("#")).isEqualTo("\\#");
+        softly.assertThat(CssSelectorUtils.escape("$")).isEqualTo("\\$");
+        softly.assertThat(CssSelectorUtils.escape("%")).isEqualTo("\\%");
+        softly.assertThat(CssSelectorUtils.escape("&")).isEqualTo("\\&");
+        softly.assertThat(CssSelectorUtils.escape("'")).isEqualTo("\\'");
+        softly.assertThat(CssSelectorUtils.escape("(")).isEqualTo("\\(");
+        softly.assertThat(CssSelectorUtils.escape(")")).isEqualTo("\\)");
+        softly.assertThat(CssSelectorUtils.escape("*")).isEqualTo("\\*");
+        softly.assertThat(CssSelectorUtils.escape("+")).isEqualTo("\\+");
+        softly.assertThat(CssSelectorUtils.escape(",")).isEqualTo("\\,");
+        softly.assertThat(CssSelectorUtils.escape("-")).isEqualTo("\\-");
+        softly.assertThat(CssSelectorUtils.escape(".")).isEqualTo("\\.");
+        softly.assertThat(CssSelectorUtils.escape("/")).isEqualTo("\\/");
+        softly.assertThat(CssSelectorUtils.escape(":")).isEqualTo("\\:");
+        softly.assertThat(CssSelectorUtils.escape(";")).isEqualTo("\\;");
+        softly.assertThat(CssSelectorUtils.escape("<")).isEqualTo("\\<");
+        softly.assertThat(CssSelectorUtils.escape("=")).isEqualTo("\\=");
+        softly.assertThat(CssSelectorUtils.escape(">")).isEqualTo("\\>");
+        softly.assertThat(CssSelectorUtils.escape("?")).isEqualTo("\\?");
+        softly.assertThat(CssSelectorUtils.escape("@")).isEqualTo("\\@");
+        softly.assertThat(CssSelectorUtils.escape("[")).isEqualTo("\\[");
+        softly.assertThat(CssSelectorUtils.escape("\\")).isEqualTo("\\\\");
+        softly.assertThat(CssSelectorUtils.escape("]")).isEqualTo("\\]");
+        softly.assertThat(CssSelectorUtils.escape("^")).isEqualTo("\\^");
+        softly.assertThat(CssSelectorUtils.escape("`")).isEqualTo("\\`");
+        softly.assertThat(CssSelectorUtils.escape("{")).isEqualTo("\\{");
+        softly.assertThat(CssSelectorUtils.escape("|")).isEqualTo("\\|");
+        softly.assertThat(CssSelectorUtils.escape("}")).isEqualTo("\\}");
+        softly.assertThat(CssSelectorUtils.escape("~")).isEqualTo("\\~");
+        softly.assertAll();
+    }
+
+}

--- a/webtester-core/src/test/java/info/novatec/testit/webtester/pagefragments/identification/producers/IdEndsWithTest.java
+++ b/webtester-core/src/test/java/info/novatec/testit/webtester/pagefragments/identification/producers/IdEndsWithTest.java
@@ -14,7 +14,7 @@ public class IdEndsWithTest {
     public void producesCorrectBy() {
         By by = cut.createBy(":partial-id");
         assertThat(by).isInstanceOf(By.ByCssSelector.class);
-        assertThat(by).hasToString("By.cssSelector: [id$=':partial-id']");
+        assertThat(by).hasToString("By.cssSelector: [id$='\\:partial\\-id']");
     }
 
     @Test

--- a/webtester-core/src/test/java/info/novatec/testit/webtester/pagefragments/identification/producers/IdStartsWithTest.java
+++ b/webtester-core/src/test/java/info/novatec/testit/webtester/pagefragments/identification/producers/IdStartsWithTest.java
@@ -14,7 +14,7 @@ public class IdStartsWithTest {
     public void producesCorrectBy() {
         By by = cut.createBy("partial-id:");
         assertThat(by).isInstanceOf(By.ByCssSelector.class);
-        assertThat(by).hasToString("By.cssSelector: [id^='partial-id:']");
+        assertThat(by).hasToString("By.cssSelector: [id^='partial\\-id\\:']");
     }
 
     @Test

--- a/webtester-core/src/test/java/integration/pagefragments/identification/IdentificationIntegrationTest.java
+++ b/webtester-core/src/test/java/integration/pagefragments/identification/IdentificationIntegrationTest.java
@@ -90,9 +90,9 @@ public class IdentificationIntegrationTest extends BaseIntegrationTest {
 
         @IdentifyUsing(value = "id", how = Id.class)
         TextField byId();
-        @IdentifyUsing(value = "prefix-", how = IdStartsWith.class)
+        @IdentifyUsing(value = "prefix:", how = IdStartsWith.class)
         TextField byIdStartsWith();
-        @IdentifyUsing(value = "-suffix", how = IdEndsWith.class)
+        @IdentifyUsing(value = ":suffix", how = IdEndsWith.class)
         TextField byIdEndsWith();
         @IdentifyUsing(value = "//div[@id='xpath']/input", how = XPath.class)
         TextField byXpath();

--- a/webtester-core/src/test/resources/html/pagefragments/identification/by-producers.html
+++ b/webtester-core/src/test/resources/html/pagefragments/identification/by-producers.html
@@ -19,11 +19,11 @@
 			</tr>
 			<tr>
 				<td>ID_STARTS_WITH</td>
-				<td><input id="prefix-bar" value="id starts with"></td>
+				<td><input id="prefix:bar" value="id starts with"></td>
 			</tr>
 			<tr>
 				<td>ID_ENDS_WITH</td>
-				<td><input id="foo-suffix" value="id ends with"></td>
+				<td><input id="foo:suffix" value="id ends with"></td>
 			</tr>
 			<tr>
 				<td>XPATH</td>


### PR DESCRIPTION
This is necessary because we are using a CSS Selector and there are issues with special characters which leads to strange behavior.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/testit-webtester/webtester2-core/36)

<!-- Reviewable:end -->
