### PR TITLE
Added warning about unsupported commands in certain WebDrivers

### DIFF
--- a/webtester-core/src/main/java/info/novatec/testit/webtester/mouse/DefaultMouseDriver.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/mouse/DefaultMouseDriver.java
@@ -7,6 +7,7 @@ import java.util.Collection;
 import java.util.function.BiFunction;
 
 import org.openqa.selenium.TimeoutException;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
 
@@ -20,6 +21,10 @@ import info.novatec.testit.webtester.waiting.Wait;
 
 /**
  * The default implementation of a {@link MouseDriver}.
+ * <p>
+ * <b>Note:</b> Methods provided by this class depend on Selenium's {@link Actions} class.
+ * There are some {@link WebDriver} implementation (e.g. v3.0.1 of the Marionette-based FirefoxDriver)
+ * which do not support the commands issued by {@link Actions}!
  *
  * @since 2.0
  */

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/mouse/Mouse.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/mouse/Mouse.java
@@ -19,6 +19,10 @@ import info.novatec.testit.webtester.pagefragments.PageFragment;
 
 /**
  * This class is used to perform a variety of mouse related actions.
+ * <p>
+ * <b>Note:</b> Methods provided by this class depend on Selenium's {@link Actions} class.
+ * There are some {@link WebDriver} implementation (e.g. v3.0.1 of the Marionette-based FirefoxDriver)
+ * which do not support the commands issued by {@link Actions}!
  *
  * @see OnPageFragment
  * @see Sequence


### PR DESCRIPTION
Since not all WebDriver implementations support the commands issued by Selenium's Actions class, there should be a note to point users in the right direction when issues occure.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/testit-webtester/webtester2-core/46)
<!-- Reviewable:end -->
