### PR TITLE
Make implementation threadsafe. Fix #92

### DIFF
--- a/webtester-core/src/main/java/info/novatec/testit/webtester/internal/implementation/pagefragments/PageFragmentImplementation.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/internal/implementation/pagefragments/PageFragmentImplementation.java
@@ -6,8 +6,8 @@ import static net.bytebuddy.matcher.ElementMatchers.isDefaultMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import java.lang.reflect.InvocationHandler;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.ClassFileVersion;
@@ -32,12 +32,12 @@ import info.novatec.testit.webtester.pagefragments.annotations.IdentifyUsing;
 final class PageFragmentImplementation {
 
     private static final Map<ClassLoader, Map<Class<? extends PageFragment>, Class<? extends PageFragment>>> CACHE =
-        new HashMap<>();
+        new ConcurrentHashMap<>();
 
     static Class<? extends PageFragment> getOrCreate(Class<? extends PageFragment> pageFragmentType) {
         ClassLoader classLoader = pageFragmentType.getClassLoader();
         Map<Class<? extends PageFragment>, Class<? extends PageFragment>> implementationMap =
-            CACHE.computeIfAbsent(classLoader, cl -> new HashMap<>());
+            CACHE.computeIfAbsent(classLoader, cl -> new ConcurrentHashMap<>());
         return implementationMap.computeIfAbsent(pageFragmentType, PageFragmentImplementation::create);
     }
 

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/internal/implementation/pages/PageImplementation.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/internal/implementation/pages/PageImplementation.java
@@ -6,8 +6,8 @@ import static net.bytebuddy.matcher.ElementMatchers.isDefaultMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import java.lang.reflect.InvocationHandler;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.ClassFileVersion;
@@ -27,12 +27,12 @@ import info.novatec.testit.webtester.pages.Page;
 
 final class PageImplementation {
 
-    private static final Map<ClassLoader, Map<Class<? extends Page>, Class<? extends Page>>> CACHE = new HashMap<>();
+    private static final Map<ClassLoader, Map<Class<? extends Page>, Class<? extends Page>>> CACHE = new ConcurrentHashMap<>();
 
     static Class<? extends Page> getOrCreate(Class<? extends Page> pageType) {
         ClassLoader classLoader = pageType.getClassLoader();
         Map<Class<? extends Page>, Class<? extends Page>> implementationMap =
-            CACHE.computeIfAbsent(classLoader, cl -> new HashMap<>());
+            CACHE.computeIfAbsent(classLoader, cl -> new ConcurrentHashMap<>());
         return implementationMap.computeIfAbsent(pageType, PageImplementation::create);
     }
 

--- a/webtester-support-junit5/src/main/java/info/novatec/testit/webtester/junit5/internal/TestClassAnalyzer.java
+++ b/webtester-support-junit5/src/main/java/info/novatec/testit/webtester/junit5/internal/TestClassAnalyzer.java
@@ -9,6 +9,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import info.novatec.testit.webtester.browser.Browser;
 import info.novatec.testit.webtester.events.EventListener;
@@ -57,7 +58,7 @@ class TestClassAnalyzer {
 
     private Map<String, Field> getNamedBrowserFieldsMap(List<Field> browserFields) {
         Set<String> uniqueNames = new HashSet<>();
-        Map<String, Field> nameToFieldMap = new HashMap<>();
+        Map<String, Field> nameToFieldMap = new ConcurrentHashMap<>();
         browserFields.forEach(field -> {
             String browserName = field.getAnnotation(Managed.class).value();
             if (uniqueNames.contains(browserName)) {


### PR DESCRIPTION
Fix #92
ConcurrentHashMap are nearly as fast as HashMap. We had ConcurrentModificationExceptions at PageImpl and PagefragmentImpl.
Changed TestClassAnalyzer to be on the safe side.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/testit-webtester/webtester2-core/93)
<!-- Reviewable:end -->
